### PR TITLE
Add react 19 support

### DIFF
--- a/dist/components/Block.js
+++ b/dist/components/Block.js
@@ -7,7 +7,7 @@ exports.default = Block;
 var _Tree = _interopRequireDefault(require("./Tree"));
 var _innerNode = _interopRequireDefault(require("../utils/innerNode"));
 var _Context = require("./Context");
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 /**
  * Block element.
  *
@@ -15,12 +15,15 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * @returns {JSX.Element | null | undefined}
  */
 function Block(_ref) {
-  var block = _ref.block;
-  var _block$blockName = block.blockName,
-    blockName = _block$blockName === void 0 ? null : _block$blockName,
-    innerContent = block.innerContent,
-    innerBlocks = block.innerBlocks;
-  var CustomBlock = (0, _Context.useBlockComponent)(blockName);
+  let {
+    block
+  } = _ref;
+  const {
+    blockName = null,
+    innerContent,
+    innerBlocks
+  } = block;
+  const CustomBlock = (0, _Context.useBlockComponent)(blockName);
   if (CustomBlock) {
     return /*#__PURE__*/React.createElement(CustomBlock, {
       block: block
@@ -35,7 +38,7 @@ function Block(_ref) {
   if (innerContent.length === 1 && (innerContent[0] === "\n" || innerContent[0].substring(0, 2) === "</")) {
     return null;
   }
-  var node = (0, _innerNode.default)(innerBlocks, innerContent);
+  const node = (0, _innerNode.default)(innerBlocks, innerContent);
   if (node) {
     return /*#__PURE__*/React.createElement(_Tree.default, {
       node: node,

--- a/dist/components/Context.js
+++ b/dist/components/Context.js
@@ -9,21 +9,23 @@ exports.useComponentContext = useComponentContext;
 exports.useTagComponent = useTagComponent;
 var _react = require("react");
 var _elements = require("../elements");
-var TxContext = /*#__PURE__*/(0, _react.createContext)();
-var Provider = TxContext.Provider;
+const TxContext = /*#__PURE__*/(0, _react.createContext)();
+const {
+  Provider
+} = TxContext;
 exports.Provider = Provider;
 function useComponentContext() {
   return (0, _react.useContext)(TxContext);
 }
 function useBlockComponent(name) {
-  var _useContext = (0, _react.useContext)(TxContext),
-    _useContext$CustomBlo = _useContext.CustomBlocks,
-    CustomBlocks = _useContext$CustomBlo === void 0 ? _elements.coreBlocks : _useContext$CustomBlo;
+  const {
+    CustomBlocks = _elements.coreBlocks
+  } = (0, _react.useContext)(TxContext);
   return name && CustomBlocks[name];
 }
 function useTagComponent(tag) {
-  var _useContext2 = (0, _react.useContext)(TxContext),
-    _useContext2$CustomTa = _useContext2.CustomTags,
-    CustomTags = _useContext2$CustomTa === void 0 ? _elements.coreTags : _useContext2$CustomTa;
+  const {
+    CustomTags = _elements.coreTags
+  } = (0, _react.useContext)(TxContext);
   return tag && CustomTags[tag];
 }

--- a/dist/components/Tree.js
+++ b/dist/components/Tree.js
@@ -7,23 +7,21 @@ exports.default = Tree;
 var _Context = require("./Context");
 var _Block = _interopRequireDefault(require("./Block"));
 var _attribsProps = _interopRequireDefault(require("../utils/attribsProps"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 function Tree(_ref) {
-  var _node$children;
-  var node = _ref.node,
-    block = _ref.block;
-  var CustomTag = (0, _Context.useTagComponent)(node.name);
+  let {
+    node,
+    block
+  } = _ref;
+  const CustomTag = (0, _Context.useTagComponent)(node.name);
   (0, _attribsProps.default)(node.attribs);
   if (node.type === "text") {
     if (node.data === "[innerBlocks]") {
-      var _block$innerBlocks;
       // eslint-disable-next-line react/no-array-index-key
-      return (_block$innerBlocks = block.innerBlocks) === null || _block$innerBlocks === void 0 ? void 0 : _block$innerBlocks.map(function (inner, index) {
-        return /*#__PURE__*/React.createElement(_Block.default, {
-          block: inner,
-          key: index
-        });
-      });
+      return block.innerBlocks?.map((inner, index) => /*#__PURE__*/React.createElement(_Block.default, {
+        block: inner,
+        key: index
+      }));
     }
     return node.data;
   }
@@ -34,17 +32,14 @@ function Tree(_ref) {
       attribs: node.attribs
     });
   }
-  var Component = node.name;
-  var attrs = (0, _attribsProps.default)(node.attribs);
-  return /*#__PURE__*/React.createElement(Component, attrs, (_node$children = node.children) === null || _node$children === void 0 ? void 0 : _node$children.map(function (child, index) {
-    return (
-      /*#__PURE__*/
-      // eslint-disable-next-line react/no-array-index-key
-      React.createElement(Tree, {
-        node: child,
-        block: block,
-        key: index
-      })
-    );
-  }));
+  const Component = node.name;
+  const attrs = (0, _attribsProps.default)(node.attribs);
+  return /*#__PURE__*/React.createElement(Component, attrs, node.children?.map((child, index) =>
+  /*#__PURE__*/
+  // eslint-disable-next-line react/no-array-index-key
+  React.createElement(Tree, {
+    node: child,
+    block: block,
+    key: index
+  })));
 }

--- a/dist/elements/index.js
+++ b/dist/elements/index.js
@@ -6,33 +6,38 @@ Object.defineProperty(exports, "__esModule", {
 exports.customTags = exports.customBlocks = exports.coreTags = exports.coreBlocks = void 0;
 var _img = _interopRequireDefault(require("./tags/img"));
 var _selfClosing = _interopRequireDefault(require("./tags/selfClosing"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
-function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-var coreTags = {
-  img: function img(_ref) {
-    var attribs = _ref.attribs;
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+const coreTags = exports.coreTags = {
+  img: _ref => {
+    let {
+      attribs
+    } = _ref;
     return /*#__PURE__*/React.createElement(_img.default, {
       attribs: attribs
     });
   },
-  br: function br(_ref2) {
-    var attribs = _ref2.attribs;
+  br: _ref2 => {
+    let {
+      attribs
+    } = _ref2;
     return /*#__PURE__*/React.createElement(_selfClosing.default, {
       attribs: attribs,
       tag: "br"
     });
   },
-  hr: function hr(_ref3) {
-    var attribs = _ref3.attribs;
+  hr: _ref3 => {
+    let {
+      attribs
+    } = _ref3;
     return /*#__PURE__*/React.createElement(_selfClosing.default, {
       attribs: attribs,
       tag: "hr"
     });
   },
-  meta: function meta(_ref4) {
-    var attribs = _ref4.attribs;
+  meta: _ref4 => {
+    let {
+      attribs
+    } = _ref4;
     return null;
   }
   // area: ({attribs}) => <SelfClosing attribs={attribs} tag="area" />,
@@ -47,8 +52,7 @@ var coreTags = {
   // track: ({attribs}) => <SelfClosing attribs={attribs} tag="track" />,
   // wbr: ({attribs}) => <SelfClosing attribs={attribs} tag="wbr" />,
 };
-exports.coreTags = coreTags;
-var coreBlocks = {
+const coreBlocks = exports.coreBlocks = {
   // 'core/archives': ({ block }) => doSomething(),
   // 'core/audio': ({ block }) => doSomething(),
   // 'core/avatar': ({ block }) => doSomething(),
@@ -150,10 +154,12 @@ var coreBlocks = {
  * @param {object} tags - Optional object with custom blocks definitions. Empty by default.
  * @returns {object} Object with blocks definitions
  */
-exports.coreBlocks = coreBlocks;
-var customTags = function customTags() {
-  var tags = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-  return _objectSpread(_objectSpread({}, coreTags), tags);
+const customTags = function () {
+  let tags = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  return {
+    ...coreTags,
+    ...tags
+  };
 };
 
 /**
@@ -164,8 +170,11 @@ var customTags = function customTags() {
  * @returns {object} Object with blocks definitions
  */
 exports.customTags = customTags;
-var customBlocks = function customBlocks() {
-  var blocks = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-  return _objectSpread(_objectSpread({}, coreBlocks), blocks);
+const customBlocks = function () {
+  let blocks = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  return {
+    ...coreBlocks,
+    ...blocks
+  };
 };
 exports.customBlocks = customBlocks;

--- a/dist/elements/tags/img.js
+++ b/dist/elements/tags/img.js
@@ -5,14 +5,16 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = Image;
 function Image(_ref) {
-  var attribs = _ref.attribs;
-  var _attribs$alt = attribs.alt,
-    alt = _attribs$alt === void 0 ? '' : _attribs$alt,
-    _attribs$class = attribs.class,
-    className = _attribs$class === void 0 ? '' : _attribs$class,
-    src = attribs.src,
-    height = attribs.height,
-    width = attribs.width;
+  let {
+    attribs
+  } = _ref;
+  const {
+    alt = '',
+    class: className = '',
+    src,
+    height,
+    width
+  } = attribs;
   return /*#__PURE__*/React.createElement("img", {
     alt: alt,
     className: className,

--- a/dist/elements/tags/selfClosing.js
+++ b/dist/elements/tags/selfClosing.js
@@ -5,11 +5,13 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = SelfClosing;
 var _attribsProps = _interopRequireDefault(require("../../utils/attribsProps"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 function SelfClosing(_ref) {
-  var attribs = _ref.attribs,
-    tag = _ref.tag;
-  var Component = tag;
-  var attributes = (0, _attribsProps.default)(attribs);
+  let {
+    attribs,
+    tag
+  } = _ref;
+  const Component = tag;
+  const attributes = (0, _attribsProps.default)(attribs);
   return /*#__PURE__*/React.createElement(Component, attributes);
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -5,49 +5,49 @@ Object.defineProperty(exports, "__esModule", {
 });
 Object.defineProperty(exports, "Block", {
   enumerable: true,
-  get: function get() {
+  get: function () {
     return _Block.default;
   }
 });
 Object.defineProperty(exports, "Provider", {
   enumerable: true,
-  get: function get() {
+  get: function () {
     return _Context.Provider;
   }
 });
 Object.defineProperty(exports, "Tree", {
   enumerable: true,
-  get: function get() {
+  get: function () {
     return _Tree.default;
   }
 });
 Object.defineProperty(exports, "attribsProps", {
   enumerable: true,
-  get: function get() {
+  get: function () {
     return _attribsProps.default;
   }
 });
 Object.defineProperty(exports, "customBlocks", {
   enumerable: true,
-  get: function get() {
+  get: function () {
     return _elements.customBlocks;
   }
 });
 Object.defineProperty(exports, "customTags", {
   enumerable: true,
-  get: function get() {
+  get: function () {
     return _elements.customTags;
   }
 });
 Object.defineProperty(exports, "innerNode", {
   enumerable: true,
-  get: function get() {
+  get: function () {
     return _innerNode.default;
   }
 });
 Object.defineProperty(exports, "parseBlocks", {
   enumerable: true,
-  get: function get() {
+  get: function () {
     return _parseBlocks.default;
   }
 });
@@ -58,4 +58,4 @@ var _elements = require("./elements");
 var _attribsProps = _interopRequireDefault(require("./utils/attribsProps"));
 var _innerNode = _interopRequireDefault(require("./utils/innerNode"));
 var _parseBlocks = _interopRequireDefault(require("./utils/parseBlocks"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }

--- a/dist/utils/attribsProps.js
+++ b/dist/utils/attribsProps.js
@@ -6,12 +6,12 @@ Object.defineProperty(exports, "__esModule", {
 exports.default = void 0;
 var _reactAttrConverter = _interopRequireDefault(require("react-attr-converter"));
 var _styleToJs = _interopRequireDefault(require("style-to-js"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-var attribsProps = function attribsProps(attribs) {
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+const attribsProps = attribs => {
   if (attribs === undefined) {
     return {};
   }
-  var props = Object.fromEntries(Object.entries(attribs).map(function (attribute) {
+  const props = Object.fromEntries(Object.entries(attribs).map(attribute => {
     if (attribute[0] === 'style') {
       return [(0, _reactAttrConverter.default)(attribute[0]), (0, _styleToJs.default)(attribute[1])];
     }
@@ -19,5 +19,4 @@ var attribsProps = function attribsProps(attribs) {
   }));
   return props;
 };
-var _default = attribsProps;
-exports.default = _default;
+var _default = exports.default = attribsProps;

--- a/dist/utils/innerNode.js
+++ b/dist/utils/innerNode.js
@@ -5,17 +5,15 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = void 0;
 var _htmlparser = require("htmlparser2");
-var innerNode = function innerNode(innerBlocks, innerContent) {
-  var _tree$children$;
+const innerNode = (innerBlocks, innerContent) => {
   // If no inner blocks, return the block markup.
   // If inner blocks, return the wrapping markup.
-  var innerHtml = !innerBlocks.length ? innerContent[0] : "".concat(innerContent[0], "[innerBlocks]").concat(innerContent[innerContent.length - 1]);
-  var html = innerHtml ? innerHtml.trim() : "";
-  var tree = (0, _htmlparser.parseDocument)(html, {
+  const innerHtml = !innerBlocks.length ? innerContent[0] : `${innerContent[0]}[innerBlocks]${innerContent[innerContent.length - 1]}`;
+  const html = innerHtml ? innerHtml.trim() : "";
+  const tree = (0, _htmlparser.parseDocument)(html, {
     lowerCaseTags: true,
     recognizeSelfClosing: true
   });
-  return (_tree$children$ = tree.children[0]) !== null && _tree$children$ !== void 0 ? _tree$children$ : null;
+  return tree.children[0] ?? null;
 };
-var _default = innerNode;
-exports.default = _default;
+var _default = exports.default = innerNode;

--- a/dist/utils/parseBlocks.js
+++ b/dist/utils/parseBlocks.js
@@ -6,20 +6,15 @@ Object.defineProperty(exports, "__esModule", {
 exports.default = void 0;
 var _blockSerializationDefaultParser = require("@wordpress/block-serialization-default-parser");
 var _Block = _interopRequireDefault(require("../components/Block"));
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
 /**
  * Parse Gutenberg blocks from HTML markup.
  *
  * @param {string} html - markup rendered by Gutenberg editor.
  * @returns {JSX.Element[]}
  */
-var parseBlocks = function parseBlocks(html) {
-  return (0, _blockSerializationDefaultParser.parse)(html.trim()).map(function (block, key) {
-    return /*#__PURE__*/React.createElement(_Block.default, {
-      block: block,
-      key: key
-    });
-  });
-};
-var _default = parseBlocks;
-exports.default = _default;
+const parseBlocks = html => (0, _blockSerializationDefaultParser.parse)(html.trim()).map((block, key) => /*#__PURE__*/React.createElement(_Block.default, {
+  block: block,
+  key: key
+}));
+var _default = exports.default = parseBlocks;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rm -rf dist && NODE_ENV=production babel src --out-dir dist --copy-files",
     "test": "node --test"
   },
-  "keywords":  [
+  "keywords": [
     "html",
     "react",
     "parser",
@@ -17,8 +17,8 @@
   "author": "Roberto Ornelas <rob@frontkom.com>",
   "license": "ISC",
   "dependencies": {
-    "@wordpress/block-serialization-default-parser": "^4.21.0",
-    "htmlparser2":  "^8.0.1",
+    "@wordpress/block-serialization-default-parser": "^5.37.0",
+    "htmlparser2": "^8.0.1",
     "react-attr-converter": "^0.3.1",
     "style-to-js": "^1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "rm -rf dist && NODE_ENV=production babel src --out-dir dist --copy-files"
   },
-  "keywords": [
+  "keywords":  [
     "html",
     "react",
     "parser",
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@wordpress/block-serialization-default-parser": "^4.21.0",
-    "htmlparser2": "^8.0.1",
+    "htmlparser2":  "^8.0.1",
     "react-attr-converter": "^0.3.1",
     "style-to-js": "^1.1.1"
   },
@@ -26,12 +26,12 @@
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
-    "build": "rm -rf dist && NODE_ENV=production babel src --out-dir dist --copy-files"
+    "build": "rm -rf dist && NODE_ENV=production babel src --out-dir dist --copy-files",
+    "test": "node --test"
   },
   "keywords":  [
     "html",

--- a/test/parser.test.mjs
+++ b/test/parser.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parse } from '@wordpress/block-serialization-default-parser';
+
+const html = `
+<!-- wp:columns {"columns":3} -->
+<div class="wp-block-columns has-3-columns">
+    <!-- wp:column -->
+    <div class="wp-block-column">
+        <!-- wp:paragraph -->
+        <p>Left</p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column">
+        <!-- wp:paragraph -->
+        <p><strong>Middle</strong></p>
+        <!-- /wp:paragraph -->
+    </div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column"></div>
+    <!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+`;
+
+test('parses columns block structure', () => {
+  const blocks = parse(html.trim());
+  assert.equal(blocks.length, 1);
+
+  const [columns] = blocks;
+  assert.equal(columns.blockName, 'core/columns');
+  assert.deepStrictEqual(columns.attrs, { columns: 3 });
+  assert.equal(columns.innerBlocks.length, 3);
+
+  const [first, second, third] = columns.innerBlocks;
+
+  assert.equal(first.blockName, 'core/column');
+  assert.deepStrictEqual(first.attrs ?? {}, {});
+  assert.equal(first.innerBlocks.length, 1);
+  assert.equal(first.innerBlocks[0].blockName, 'core/paragraph');
+  assert.deepStrictEqual(first.innerBlocks[0].attrs ?? {}, {});
+  assert.equal(first.innerBlocks[0].innerBlocks.length, 0);
+  assert.equal(first.innerBlocks[0].innerHTML.trim(), '<p>Left</p>');
+
+  assert.equal(second.blockName, 'core/column');
+  assert.deepStrictEqual(second.attrs ?? {}, {});
+  assert.equal(second.innerBlocks.length, 1);
+  assert.equal(second.innerBlocks[0].blockName, 'core/paragraph');
+  assert.deepStrictEqual(second.innerBlocks[0].attrs ?? {}, {});
+  assert.equal(second.innerBlocks[0].innerBlocks.length, 0);
+  assert.equal(second.innerBlocks[0].innerHTML.trim(), '<p><strong>Middle</strong></p>');
+
+  assert.equal(third.blockName, 'core/column');
+  assert.deepStrictEqual(third.attrs ?? {}, {});
+  assert.equal(third.innerBlocks.length, 0);
+});


### PR DESCRIPTION
This pull request updates dependencies to support React 19, expands peer dependency compatibility, and introduces a new test for parsing WordPress columns block structures. The most important changes are:

**Dependency Updates:**

* Upgraded `react` and `react-dom` dependencies to version 19.0.0 in both `dependencies` and expanded `peerDependencies` to support React 17, 18, and 19.
* Updated `@wordpress/block-serialization-default-parser` to version 5.37.0.

**Testing Improvements:**

* Added a new test file `test/parser.test.mjs` that uses Node.js’s built-in test runner to verify the parsing of a WordPress columns block structure.
* Added a `test` script to `package.json` to run Node.js tests.