### PR TITLE
Fix [innerBlocks] marker leaking when it shares a text node with content

### DIFF
--- a/dist/components/Tree.js
+++ b/dist/components/Tree.js
@@ -19,10 +19,15 @@ function Tree(_ref) {
   const CustomTag = (0, _Context.useTagComponent)(node.name);
   (0, _attribsProps.default)(node.attribs);
   if (node.type === "text") {
-    if (node.data.trim() === "[innerBlocks]") {
-      return block.innerBlocks?.map((inner, index) => /*#__PURE__*/(0, _jsxRuntime.jsx)(_Block.default, {
-        block: inner
-      }, index));
+    // The [innerBlocks] marker may share its text node with block content,
+    // e.g. a list item with a nested list: "<li>Some item[innerBlocks]</li>".
+    if (node.data.includes("[innerBlocks]")) {
+      const [before, after] = node.data.split("[innerBlocks]");
+      return /*#__PURE__*/(0, _jsxRuntime.jsxs)(_jsxRuntime.Fragment, {
+        children: [before.trim() ? before : null, block.innerBlocks?.map((inner, index) => /*#__PURE__*/(0, _jsxRuntime.jsx)(_Block.default, {
+          block: inner
+        }, index)), after.trim() ? after : null]
+      });
     }
     return node.data;
   }

--- a/src/components/Tree.jsx
+++ b/src/components/Tree.jsx
@@ -9,10 +9,19 @@ export default function Tree({ node, block }) {
   attribsProps(node.attribs);
 
   if (node.type === "text") {
-    if (node.data.trim() === "[innerBlocks]") {
-      return block.innerBlocks?.map((inner, index) => (
-        <Block block={inner} key={index} />
-      ));
+    // The [innerBlocks] marker may share its text node with block content,
+    // e.g. a list item with a nested list: "<li>Some item[innerBlocks]</li>".
+    if (node.data.includes("[innerBlocks]")) {
+      const [before, after] = node.data.split("[innerBlocks]");
+      return (
+        <>
+          {before.trim() ? before : null}
+          {block.innerBlocks?.map((inner, index) => (
+            <Block block={inner} key={index} />
+          ))}
+          {after.trim() ? after : null}
+        </>
+      );
     }
 
     return node.data;

--- a/test/block.test.mjs
+++ b/test/block.test.mjs
@@ -281,6 +281,39 @@ test('Block component renders ordered list', () => {
   assert.ok(rendered.includes('Step two'), 'Should render second step');
 });
 
+test('Block component renders nested list inside list item', () => {
+  // Gutenberg serializes a nested list as inner blocks of a list-item, so the
+  // list-item's innerContent is ["<li>Some item", null, "</li>"] and the
+  // [innerBlocks] marker ends up in the SAME text node as the item text.
+  const html = `
+<!-- wp:list -->
+<ul class="wp-block-list">
+<!-- wp:list-item -->
+<li>Some item<!-- wp:list -->
+<ul class="wp-block-list">
+<!-- wp:list-item -->
+<li>A sub item</li>
+<!-- /wp:list-item -->
+</ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item -->
+</ul>
+<!-- /wp:list -->
+`;
+
+  const rendered = parseAndRender(html);
+
+  assert.ok(!rendered.includes('[innerBlocks]'), 'Should not leak the [innerBlocks] marker');
+  assert.ok(rendered.includes('Some item'), 'Should render parent item text');
+  assert.ok(rendered.includes('A sub item'), 'Should render nested item text');
+
+  const ulCount = (rendered.match(/<ul/g) || []).length;
+  assert.equal(ulCount, 2, 'Should render nested ul inside the list item');
+
+  const nested = /<li>Some item<ul[^>]*>.*<li>A sub item<\/li>.*<\/ul><\/li>/s;
+  assert.ok(nested.test(rendered), 'Nested list should render inside the parent li');
+});
+
 // ============ Quote Block Render Tests ============
 test('Block component renders quote block', () => {
   const html = `


### PR DESCRIPTION
## Summary
- Handle the `[innerBlocks]` marker when it shares a text node with block content, e.g. a list item with a nested list: `<li>Some item[innerBlocks]</li>`.
- Add a regression test covering a nested `core/list` inside a `core/list-item`.

## Why
- Gutenberg serializes nested lists as inner blocks of a list item, so the item's `innerContent` is `["<li>Some item", null, "</li>"]`. `Tree` only substituted inner blocks when the entire text node equaled the marker, so consumers (e.g. sikt.no accordion content) rendered a literal `[innerBlocks]` and dropped the nested list.

## Notes
- Whitespace-only segments around the marker are dropped, preserving the previous output for standalone markers.
- Needs a version bump + tag (`v1.4.4`) after merge for consumers pinned to `^1.4.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)